### PR TITLE
Adds support for transitions on set fader level and set send level actions

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,5 @@
 const { combineRgb } = require('@companion-module/base')
+const { FadeDurationChoice } = require('./fades')
 
 module.exports = {
 	/**
@@ -111,6 +112,7 @@ module.exports = {
 					choices: this.CHOICES_FADER,
 					minChoicesForSearch: 0,
 				},
+				...FadeDurationChoice()
 			]
 		}
 
@@ -218,14 +220,14 @@ module.exports = {
 				name: 'Set Input Fader to Level',
 				options: this.faderOptions('Channel', 128, -1),
 				callback: async (action) => {
-					this.sendAction('fader_input', action.options)
+					this.sendActionWithFade('fader_input', action.options)
 				},
 			}
 			actions['fader_mono_group'] = {
 				name: 'Set Mono Group Master Fader to Level',
 				options: this.faderOptions('Mono Group', 62, -1),
 				callback: async (action) => {
-					this.sendAction('fader_mono_group', action.options)
+					this.sendActionWithFade('fader_mono_group', action.options)
 				},
 			}
 			actions['fader_stereo_group'] = {
@@ -689,6 +691,7 @@ module.exports = {
 					choices: this.CHOICES_FADER,
 					minChoicesForSearch: 0,
 				},
+				...FadeDurationChoice()
 			]
 		}
 
@@ -698,7 +701,7 @@ module.exports = {
 				name: 'Set Aux Mono Send Level',
 				options: this.sendLevelOptions('Mono Aux', 62, -1),
 				callback: async (action) => {
-					this.sendAction('send_aux_mono', action.options)
+					this.sendActionWithFade('send_aux_mono', action.options)
 				},
 			}
 
@@ -706,7 +709,7 @@ module.exports = {
 				name: 'Set Aux Stereo Send Level',
 				options: this.sendLevelOptions('Stereo Aux', 31, 0x3f),
 				callback: async (action) => {
-					this.sendAction('send_aux_stereo', action.options)
+					this.sendActionWithFade('send_aux_stereo', action.options)
 				},
 			}
 
@@ -714,7 +717,7 @@ module.exports = {
 				name: 'Set FX Mono Send Level',
 				options: this.sendLevelOptions('Mono FX', 16, -1),
 				callback: async (action) => {
-					this.sendAction('send_fx_mono', action.options)
+					this.sendActionWithFade('send_fx_mono', action.options)
 				},
 			}
 
@@ -722,7 +725,7 @@ module.exports = {
 				name: 'Set FX Stereo Send Level',
 				options: this.sendLevelOptions('Stereo FX', 16, 0x0f),
 				callback: async (action) => {
-					this.sendAction('send_fx_stereo', action.options)
+					this.sendActionWithFade('send_fx_stereo', action.options)
 				},
 			}
 
@@ -730,7 +733,7 @@ module.exports = {
 				name: 'Set Matrix Mono Send Level',
 				options: this.sendLevelOptions('Mono Matrix', 62, -1),
 				callback: async (action) => {
-					this.sendAction('send_matrix_mono', action.options)
+					this.sendActionWithFade('send_matrix_mono', action.options)
 				},
 			}
 
@@ -738,7 +741,7 @@ module.exports = {
 				name: 'Set Matrix Stereo Send Level',
 				options: this.sendLevelOptions('Stereo Matrix', 31, 0x3f),
 				callback: async (action) => {
-					this.sendAction('send_matrix_stereo', action.options)
+					this.sendActionWithFade('send_matrix_stereo', action.options)
 				},
 			}
 
@@ -747,7 +750,7 @@ module.exports = {
 				name: 'Set UFX Stereo Send Level',
 				options: this.sendLevelOptions('UFX Stereo Send', 8, 0x55),
 				callback: async (action) => {
-					this.sendAction('send_ufx', action.options)
+					this.sendActionWithFade('send_ufx', action.options)
 				},
 			}
 

--- a/easings.js
+++ b/easings.js
@@ -1,0 +1,241 @@
+/**
+ * A collection of easing methods defining ease-in ease-out curves from https://github.com/photonstorm/phaser licensed
+ * under MIT
+ *
+ * @class Easing
+ */
+
+function getEasing(algorithm, curve) {
+    if (algorithm == 'linear' || algorithm == null || curve == null) {
+        return Linear.None;
+    }
+    if (algorithm == 'quadratic' && curve == 'ease-in') return Quadratic.In;
+    if (algorithm == 'quadratic' && curve == 'ease-out') return Quadratic.Out;
+    if (algorithm == 'quadratic' && curve == 'ease-in-out') return Quadratic.InOut;
+    if (algorithm == 'cubic' && curve == 'ease-in') return Cubic.In;
+    if (algorithm == 'cubic' && curve == 'ease-out') return Cubic.Out;
+    if (algorithm == 'cubic' && curve == 'ease-in-out') return Cubic.InOut;
+    if (algorithm == 'quartic' && curve == 'ease-in') return Quartic.In;
+    if (algorithm == 'quartic' && curve == 'ease-out') return Quartic.Out;
+    if (algorithm == 'quartic' && curve == 'ease-in-out') return Quartic.InOut;
+    if (algorithm == 'quintic' && curve == 'ease-in') return Quintic.In;
+    if (algorithm == 'quintic' && curve == 'ease-out') return Quintic.Out;
+    if (algorithm == 'quintic' && curve == 'ease-in-out') return Quintic.InOut;
+    if (algorithm == 'sinusoidal' && curve == 'ease-in') return Sinusoidal.In;
+    if (algorithm == 'sinusoidal' && curve == 'ease-out') return Sinusoidal.Out;
+    if (algorithm == 'sinusoidal' && curve == 'ease-in-out') return Sinusoidal.InOut;
+    if (algorithm == 'exponential' && curve == 'ease-in') return Exponential.In;
+    if (algorithm == 'exponential' && curve == 'ease-out') return Exponential.Out;
+    if (algorithm == 'exponential' && curve == 'ease-in-out') return Exponential.InOut;
+    if (algorithm == 'circular' && curve == 'ease-in') return Circular.In;
+    if (algorithm == 'circular' && curve == 'ease-out') return Circular.Out;
+    if (algorithm == 'circular' && curve == 'ease-in-out') return Circular.InOut;
+    if (algorithm == 'elastic' && curve == 'ease-in') return Elastic.In;
+    if (algorithm == 'elastic' && curve == 'ease-out') return Elastic.Out;
+    if (algorithm == 'elastic' && curve == 'ease-in-out') return Elastic.InOut;
+    if (algorithm == 'back' && curve == 'ease-in') return Back.In;
+    if (algorithm == 'back' && curve == 'ease-out') return Back.Out;
+    if (algorithm == 'back' && curve == 'ease-in-out') return Back.InOut;
+    if (algorithm == 'bounce' && curve == 'ease-in') return Bounce.In;
+    if (algorithm == 'bounce' && curve == 'ease-out') return Bounce.Out;
+    if (algorithm == 'bounce' && curve == 'ease-in-out') return Bounce.InOut;
+    return Linear.None;
+}
+
+class Linear {
+    static None(k) {
+        return k;
+    }
+}
+
+class Quadratic {
+    static In(k) {
+        return k * k;
+    }
+    static Out(k) {
+        return k * (2 - k);
+    }
+    static InOut(k) {
+        k *= 2;
+        if (k < 1) return 0.5 * k * k;
+        return -0.5 * (--k * (k - 2) - 1);
+    }
+}
+
+class Cubic {
+    static In(k) {
+        return k * k * k;
+    }
+    static Out(k) {
+        return --k * k * k + 1;
+    }
+    static InOut(k) {
+        k *= 2;
+        if (k < 1) return 0.5 * k * k * k;
+        return 0.5 * ((k -= 2) * k * k + 2);
+    }
+}
+
+class Quartic {
+    static In(k) {
+        return k * k * k * k;
+    }
+    static Out(k) {
+        return 1 - --k * k * k * k;
+    }
+    static InOut(k) {
+        k *= 2;
+        if (k < 1) return 0.5 * k * k * k * k;
+        return -0.5 * ((k -= 2) * k * k * k - 2);
+    }
+}
+
+class Quintic {
+    static In(k) {
+        return k * k * k * k * k;
+    }
+    static Out(k) {
+        return --k * k * k * k * k + 1;
+    }
+    static InOut(k) {
+        k *= 2;
+        if (k < 1) return 0.5 * k * k * k * k * k;
+        return 0.5 * ((k -= 2) * k * k * k * k + 2);
+    }
+}
+
+class Sinusoidal {
+    static In(k) {
+        return 1 - Math.cos((k * Math.PI) / 2);
+    }
+    static Out(k) {
+        return Math.sin((k * Math.PI) / 2);
+    }
+    static InOut(k) {
+        return 0.5 * (1 - Math.cos(Math.PI * k));
+    }
+}
+
+class Exponential {
+    static In(k) {
+        return k === 0 ? 0 : Math.pow(1024, k - 1);
+    }
+    static Out(k) {
+        return k === 1 ? 1 : 1 - Math.pow(2, -10 * k);
+    }
+    static InOut(k) {
+        if (k === 0) return 0;
+        if (k === 1) return 1;
+        k *= 2;
+        if (k < 1) return 0.5 * Math.pow(1024, k - 1);
+        return 0.5 * (-Math.pow(2, -10 * (k - 1)) + 2);
+    }
+}
+
+class Circular {
+    static In(k) {
+        return 1 - Math.sqrt(1 - k * k);
+    }
+    static Out(k) {
+        return Math.sqrt(1 - --k * k);
+    }
+    static InOut(k) {
+        k *= 2;
+        if (k < 1) return -0.5 * (Math.sqrt(1 - k * k) - 1);
+        return 0.5 * (Math.sqrt(1 - (k -= 2) * k) + 1);
+    }
+}
+
+class Elastic {
+    static In(k) {
+        let s;
+        let a = 0.1;
+        const p = 0.4;
+        if (k === 0) return 0;
+        if (k === 1) return 1;
+        if (!a || a < 1) {
+            a = 1;
+            s = p / 4;
+        } else s = (p * Math.asin(1 / a)) / (2 * Math.PI);
+        return -(a * Math.pow(2, 10 * (k -= 1)) * Math.sin(((k - s) * (2 * Math.PI)) / p));
+    }
+    static Out(k) {
+        let s;
+        let a = 0.1;
+        const p = 0.4;
+        if (k === 0) return 0;
+        if (k === 1) return 1;
+        if (!a || a < 1) {
+            a = 1;
+            s = p / 4;
+        } else s = (p * Math.asin(1 / a)) / (2 * Math.PI);
+        return a * Math.pow(2, -10 * k) * Math.sin(((k - s) * (2 * Math.PI)) / p) + 1;
+    }
+    static InOut(k) {
+        let s;
+        let a = 0.1;
+        const p = 0.4;
+        if (k === 0) return 0;
+        if (k === 1) return 1;
+        if (!a || a < 1) {
+            a = 1;
+            s = p / 4;
+        } else s = (p * Math.asin(1 / a)) / (2 * Math.PI);
+        k *= 2;
+        if (k < 1) return -0.5 * (a * Math.pow(2, 10 * (k -= 1)) * Math.sin(((k - s) * (2 * Math.PI)) / p));
+        return a * Math.pow(2, -10 * (k -= 1)) * Math.sin(((k - s) * (2 * Math.PI)) / p) * 0.5 + 1;
+    }
+}
+
+class Back {
+    static In(k) {
+        const s = 1.70158;
+        return k * k * ((s + 1) * k - s);
+    }
+    static Out(k) {
+        const s = 1.70158;
+        return --k * k * ((s + 1) * k + s) + 1;
+    }
+    static InOut(k) {
+        const s = 1.70158 * 1.525;
+        k *= 2;
+        if (k < 1) return 0.5 * (k * k * ((s + 1) * k - s));
+        return 0.5 * ((k -= 2) * k * ((s + 1) * k + s) + 2);
+    }
+}
+
+class Bounce {
+    static In(k) {
+        return 1 - Bounce.Out(1 - k);
+    }
+    static Out(k) {
+        if (k < 1 / 2.75) {
+            return 7.5625 * k * k;
+        } else if (k < 2 / 2.75) {
+            return 7.5625 * (k -= 1.5 / 2.75) * k + 0.75;
+        } else if (k < 2.5 / 2.75) {
+            return 7.5625 * (k -= 2.25 / 2.75) * k + 0.9375;
+        } else {
+            return 7.5625 * (k -= 2.625 / 2.75) * k + 0.984375;
+        }
+    }
+    static InOut(k) {
+        if (k < 0.5) return Bounce.In(k * 2) * 0.5;
+        return Bounce.Out(k * 2 - 1) * 0.5 + 0.5;
+    }
+}
+
+module.exports = {
+    getEasing,
+    Linear,
+    Quadratic,
+    Cubic,
+    Quartic,
+    Quintic,
+    Sinusoidal,
+    Exponential,
+    Circular,
+    Elastic,
+    Back,
+    Bounce,
+};

--- a/fades.js
+++ b/fades.js
@@ -1,0 +1,251 @@
+const { getEasing } = require("./easings")
+
+/**
+ * Returns the fade duration choice fields for Companion module UI.
+ * @param {string} [isVisibleExpression]
+ * @returns {Array<Object>} Array of input field definitions
+ */
+const FadeDurationChoice = function (isVisibleExpression) {
+  return [
+    {
+      type: "number",
+      label: "Fade Duration (ms)",
+      id: "fadeDuration",
+      default: 0,
+      min: 0,
+      step: 10,
+      max: 60000,
+      tooltip:
+        "Set the desired duration of the transition in milliseconds. Be aware that the minimal temporal resolution is defined by the Fader Update Rate setting of the module.",
+      isVisibleExpression: isVisibleExpression,
+    },
+    {
+      type: "dropdown",
+      label: "Algorithm",
+      id: "fadeAlgorithm",
+      default: "linear",
+      choices: [
+        { id: "linear", label: "Linear" },
+        { id: "quadratic", label: "Quadratic" },
+        { id: "cubic", label: "Cubic" },
+        { id: "quartic", label: "Quartic" },
+        { id: "quintic", label: "Quintic" },
+        { id: "sinusoidal", label: "Sinusoidal" },
+        { id: "exponential", label: "Exponential" },
+        { id: "circular", label: "Circular" },
+        { id: "elastic", label: "Elastic" },
+        { id: "back", label: "Back" },
+        { id: "bounce", label: "Bounce" },
+      ],
+      isVisibleExpression: `$(options:fadeDuration) > 0 && (${
+        isVisibleExpression ?? "true"
+      })`,
+      tooltip: "Select the algorithm with which the fade is performed.",
+    },
+    {
+      type: "dropdown",
+      label: "Fade type",
+      id: "fadeType",
+      default: "ease-in-out",
+      choices: [
+        { id: "ease-in", label: "Ease-In" },
+        { id: "ease-out", label: "Ease-Out" },
+        { id: "ease-in-out", label: "Ease-In-Out" },
+      ],
+      isVisibleExpression: `$(options:fadeDuration) > 0 && $(options:fadeAlgorithm) != 'linear' && (${
+        isVisibleExpression ?? "true"
+      })`,
+      tooltip:
+        "Select how to ease your algorithm. Easing avoids abrupt changes in value",
+    },
+  ];
+};
+
+module.exports = {
+  FadeDurationChoice,
+};
+
+
+function runTransition(
+  cmd,
+  valueId,
+  action,
+  state,
+  transitions,
+  targetValue,
+  mapLinearToDb,
+) {
+  const current = StateUtils.getNumberFromState(cmd, state)
+  const target = targetValue ?? getNumber(action, valueId)
+  transitions.run(
+    cmd,
+    current,
+    target,
+    getNumber(action, 'fadeDuration'),
+    getAlgorithm(action, 'fadeAlgorithm'),
+    getCurve(action, 'fadeType'),
+    mapLinearToDb,
+  )
+  state.set(cmd, [{ type: 'f', value: target }])
+}
+
+class FadingWorker {
+  constructor(instance) {
+    this.transitions = new Map()
+    this.instance = instance
+    this.fadeUpdateRate = 50
+    this.tickInterval = undefined
+  }
+
+  setUpdateRate(rate) {
+    this.fadeUpdateRate = rate
+  }
+
+  sendCommand(cmd, arg) {
+    if (this.instance.config.host) {
+      this.instance.sendValueByPath(cmd, arg, true)
+    }
+  }
+
+  stopAll() {
+    this.transitions.clear()
+
+    if (this.tickInterval) {
+      clearInterval(this.tickInterval)
+      delete this.tickInterval
+    }
+  }
+
+  /**
+   * Run a single tick of all pending transitions.
+   */
+  runTick() {
+    const completedPaths = []
+    for (const [path, info] of this.transitions.entries()) {
+      const newValue = info.steps.shift()
+      if (newValue !== undefined) {
+        this.sendCommand(path, newValue)
+      }
+      if (info.steps.length === 0) {
+        completedPaths.push(path)
+      }
+    }
+
+    // Remove any completed transitions
+    for (const path of completedPaths) {
+      this.transitions.delete(path)
+    }
+
+    // If nothing is left, stop the timer
+    if (this.transitions.size === 0) {
+      this.stopAll()
+    }
+  }
+
+  /**
+   * Schedule a transition between to values using an OSC command to be executed.
+   * @param {string} path The command to execute the transition with
+   * @param {number|undefined} from Value to start the transition from
+   * @param {number} to Value to end the transition with
+   * @param {number} duration Duration of the transition
+   * @param {string} [algorithm] The fade-curve to use for the transition
+   * @param {string} [curve] The easing to use for the transition start and end
+   * @param {boolean} [mapLinearToDb] Whether to map linear to dB
+   */
+  run(path, from, to, duration, algorithm, curve, mapLinearToDb) {
+    const interval = this.fadeUpdateRate
+    const stepCount = Math.ceil(duration / interval)
+
+    if (stepCount <= 1 || typeof from !== 'number') {
+      this.transitions.delete(path)
+      this.sendCommand(path, to)
+    } else {
+      // Map the transition in dB to a linear scale (=linear fader movement)
+      if (mapLinearToDb != false) {
+        from = dbToFloat(from)
+        to = dbToFloat(to)
+      }
+      const diff = to - from
+      const steps = []
+      
+      const easing = getEasing(algorithm, curve)
+      for (let i = 1; i <= stepCount; i++) {
+        const fraction = easing(i / stepCount)
+        if (mapLinearToDb == false) {
+          steps.push(from + diff * fraction)
+        } else {
+          steps.push(floatToDb(from + diff * fraction)) // map back to dB
+        }
+      }
+
+      this.transitions.set(path, { steps })
+
+      // Start the tick if not already running
+      if (!this.tickInterval) {
+        this.tickInterval = setInterval(() => this.runTick(), this.fadeUpdateRate)
+      }
+    }
+  }
+}
+
+let maxDb = 10
+let minDb = -58.5
+let dbInterval = maxDb - minDb
+let dbHexMax = 0x7F
+
+function floatToDb(f) {
+  const value = (floatToDbAbs(f) - minDb) / dbInterval * dbHexMax
+
+  return Math.max(0, Math.min(Math.floor(value), 0x7F))
+}
+
+/**
+ * Converts a fader position to the value of that fader in dB
+ * @param {number} f Fader position between 0.0 and 1.0
+ * @returns {number} Value of the fader position in dB
+ */
+function floatToDbAbs(f) {
+  if (f > 1.0 || f < 0.0) {
+    console.error(`Illegal value for fader float ([0.0, 1.0]) = ${f}`)
+  }
+  if (f >= 0.5) {
+    return f * 40 - 30
+  } else if (f >= 0.25) {
+    return f * 80 - 50
+  } else if (f >= 0.0625) {
+    return f * 160 - 70
+  } else if (f >= 0.0) {
+    return f * 480 - 90
+  } else {
+    return Number.NEGATIVE_INFINITY
+  }
+}
+
+/**
+ * Converts a fader value in dB to a fader position
+ * @param {number} d A value of a fader in dB according to the A&H Midi Protocol (0x00: -Inf, 0x7F: +10dB)
+ * @returns {number} The fader position between 0.0 and 1.0
+ */
+function dbToFloat(d) {
+  // convert the dB value from the byte encoding of the midi protocol to an actual value 
+  d = minDb + d / dbHexMax * dbInterval
+
+  let f
+  if (d < -60) {
+    f = (d + 90) / 480
+  } else if (d < -30) {
+    f = (d + 70) / 160
+  } else if (d < -10) {
+    f = (d + 50) / 80
+  } else if (d <= 10) {
+    f = (d + 30) / 40
+  } else {
+    f = 1
+  }
+  return f
+}
+
+module.exports = {
+  FadeDurationChoice,
+  FadingWorker
+}

--- a/index.js
+++ b/index.js
@@ -8,9 +8,17 @@
 const { InstanceBase, Regex, runEntrypoint, TCPHelper } = require('@companion-module/base')
 const actions = require('./actions')
 const upgradeScripts = require('./upgrade')
+const MidiParser = require('./midi')
+const { FadingWorker } = require('./fades')
 
 const sysExHeader = [0xF0, 0, 0, 0x1a, 0x50, 0x10, 1, 0];
 
+let mixes = {
+	group: {n: 1, stereoOffset: 0x40},
+	aux: {n: 2, stereoOffset: 0x40},
+	fx: {n: 4, stereoOffset: 0x10},
+	matrix: {n: 3, stereoOffset: 0x40}
+}
 
 /**
  * @extends InstanceBase
@@ -30,6 +38,8 @@ class ModuleInstance extends InstanceBase {
 		Object.assign(this, {
 			...actions,
 		})
+
+		this.fadingWorker = new FadingWorker(this)
 	}
 
 	/**
@@ -53,6 +63,110 @@ class ModuleInstance extends InstanceBase {
 		}
 
 		return routingCmds
+	}
+
+
+	sendActionWithFade(actionId, opt) {
+		let path;
+		let inputCh = parseInt(opt.strip)
+		switch(actionId) {
+			case 'fader_input':
+			case 'fader_mix':
+				path = `0/${inputCh}/faderLevel`
+				break
+
+			case 'fader_mono_group':
+			case 'fader_stereo_group':
+				path = `1/${inputCh}/faderLevel`
+				break
+
+			case 'fader_mono_aux':
+			case 'fader_stereo_aux':
+				path = `2/${inputCh}/faderLevel`
+				break
+
+			case 'fader_mono_matrix':
+			case 'fader_stereo_matrix':
+				path = `3/${inputCh}/faderLevel`
+				break
+
+			case 'fader_DCA':
+			case 'fader_mono_fx_send':
+			case 'fader_stereo_fx_send':
+			case 'fader_fx_return':
+			case 'fader_ufx_send':
+			case 'fader_ufx_return':
+				let n = this.config.model == 'dLive' ? 4 : 0
+				path = `${n}/${inputCh}/faderLevel`
+				break
+			case 'send_aux_mono':
+			case 'send_aux_stereo':
+			case 'send_fx_mono':
+			case 'send_fx_stereo':
+			case 'send_matrix_mono':
+			case 'send_matrix_stereo':
+			case 'send_mix':
+			case 'send_fx':
+			case 'send_ufx':
+				inputCh = parseInt(opt.inputChannel)
+				let sendCh = parseInt(opt.send)
+				
+				let sendN = 0x02 // Default for aux sends
+				
+				if (actionId.includes('matrix')) {
+					sendN = 0x03 // Matrix sends
+				} else if (actionId.includes('fx')) {
+					sendN = 0x04 // FX and UFX sends
+				}
+				path = `0/${inputCh}/sendLevels/${sendN}/${sendCh}`
+				break;
+		}
+		let target = parseInt(opt.level)
+
+		let current = this.state.get(path) || 0
+		this.state.set(path, target)
+		this.fadingWorker.run(
+				path,
+				current,
+				target,
+				parseInt(opt.fadeDuration),
+				opt.fadeAlgorithm,
+				opt.fadeType,
+				true,
+		)
+	}
+
+	sendValueByPath(path, value) {
+		const parts = path.split("/")
+		const [n, channel, type] = parts
+		let cmd = { port: this.config.midiPort, buffers: [] }
+		switch (type) {
+			case "sendLevels":
+				const sendN = parts[3]
+				const sendChannel = parts[4]
+				cmd.buffers.push(Buffer.from([...sysExHeader, parseInt(n), 0x0D, parseInt(channel), sendN, sendChannel, value, 0xf7]))
+				break;
+			case "faderLevel":
+				cmd.buffers.push(
+					Buffer.from([0xb0 + parseInt(n), 0x63, parseInt(channel), 0x62, 0x17, 0x06, value])
+				)
+				break;
+			
+		}
+
+		for (let i = 0; i < cmd.buffers.length; i++) {
+			if (cmd.port === this.config.midiPort && this.midiSocket !== undefined) {
+				this.log('debug', `sending ${type} ${cmd.buffers[i].toString('hex')} via MIDI @${this.config.host}:${this.config.midiPort}`)
+				this.midiSocket.send(cmd.buffers[i]).catch((e) => {
+					this.log('error', `MIDI send error: ${e.message}`)
+				})
+			} else if (this.tcpSocket !== undefined) {
+				this.log('debug', `sending ${cmd.buffers[i].toString('hex')} via TCP @${this.config.host}:${this.config.tcpPort}`)
+				this.tcpSocket.send(cmd.buffers[i]).catch((e) => {
+					this.log('error', `TCP send error: ${e.message}`)
+				})
+			}
+		}
 	}
 
 	/**
@@ -375,10 +489,82 @@ class ModuleInstance extends InstanceBase {
 				type: 'number',
 				id: 'midiChannel',
 				label: 'MIDI Channel for dLive System (N)',
-				width: 6,
+				width: 12,
 				default: 0,
 				min: 0,
 				max: 15,
+			},
+			{
+				type: 'number',
+				id: 'monoGroup',
+				label: 'Number of Mono Groups',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoGroup',
+				label: 'Number of Stereo Groups',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'monoFx',
+				label: 'Number of Mono FX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoFx',
+				label: 'Number of Stereo FX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'monoAux',
+				label: 'Number of Mono AUX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoAux',
+				label: 'Number of Stereo AUX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'monoMatrix',
+				label: 'Number of Mono Matrices',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoMatrix',
+				label: 'Number of Stereo Matrices',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
 			},
 		]
 	}
@@ -414,6 +600,45 @@ class ModuleInstance extends InstanceBase {
 		await this.configUpdated(this.config || {})
 	}
 
+	parseMidiMessage(message) {
+		if (message.type === 0xF0) {
+			let command = message.raw[9];
+			let n = message.raw[8];
+			let channel = message.raw[10];
+			
+			// Send levels
+			if (command === 0x0D) {
+				let sendN = message.raw[11];
+				let sendChannel = message.raw[12];
+				let level = message.raw[13];
+
+				this.log("debug", `Received send level ${n} ${channel} ${sendN} ${sendChannel} ${level}`)
+				this.state.set(`${n}/${channel}/sendLevels/${sendN}/${sendChannel}`, level)
+			}
+		} else if (message.type === 0xB0) {
+			// NPRN message: typically three messages in a row to change a channel parameter
+			// 1. Select the channel
+			// 2. Select the paramter
+			// 3. Set the parameter value
+			// 
+			if (message.controller === 0x63) {
+				this.currentMidiChannel = {
+					n: message.channel,
+					channel: message.value
+				}
+			} else if (message.controller === 0x62) {
+				this.currentMidiParameter = message.value
+			} else if (message.controller === 0x06) {
+				if (this.currentMidiChannel && this.currentMidiParameter) {
+					if (this.currentMidiParameter === 0x17) {
+						this.log("debug", `Received fader level ${this.currentMidiChannel.n}/${this.currentMidiChannel.channel}/faderLevel`)
+						this.state.set(`${this.currentMidiChannel.n}/${this.currentMidiChannel.channel}/faderLevel`, message.value)
+					}
+				}
+			}
+		}
+	}
+
 	/**
 	 * INTERNAL: use setup data to initalize the tcp socket object.
 	 *
@@ -421,6 +646,7 @@ class ModuleInstance extends InstanceBase {
 	 * @since 2.0.0
 	 */
 	init_tcp() {
+		this.state = new Map();
 		if (this.tcpSocket !== undefined) {
 			this.tcpSocket.destroy()
 			delete this.tcpSocket
@@ -444,6 +670,14 @@ class ModuleInstance extends InstanceBase {
 
 			this.midiSocket.on('connect', () => {
 				this.log('debug', `MIDI Connected to ${this.config.host}`)
+				this.requestMidiValues()
+			})
+			this.midiParser = new MidiParser();
+			this.midiSocket.on('data', (e) => {
+				this.midiParser.processData(e)
+			})
+			this.midiParser.addListener("message", (message) => {
+				this.parseMidiMessage(message)
 			})
 
 			if (this.config.model == 'dLive') {
@@ -460,6 +694,39 @@ class ModuleInstance extends InstanceBase {
 				this.tcpSocket.on('connect', () => {
 					this.log('debug', `TCP Connected to ${this.config.host}`)
 				})
+			}
+		}
+	}
+
+	async requestMidiValues() {
+		if (this.config.model === "dLive") {
+			// Request fader and send level of all input channels
+			for (let i = 0; i < 128; i++) {
+				this.midiSocket.send(Buffer.from([...sysExHeader, 0, 5, 0x0b, 0x17, i, 0xF7]))
+				for (const mix of Object.keys(mixes)) {
+					let mixConfig = mixes[mix]
+					 for (const layout of ['mono', 'stereo']) {
+					 	let numberOfMixes = this.config[layout + mix[0].toUpperCase() + mix.slice(1)] || 0
+					 	let offset = layout === 'stereo' ? mixConfig.stereoOffset : 0
+
+					 	for (let sendChannel = 1; sendChannel <= numberOfMixes; sendChannel++) {
+					 		this.midiSocket.send(Buffer.from([...sysExHeader, 0, 5, 0x0F, 0x0D, i, mixConfig.n, offset + sendChannel - 1, 0xF7]))
+					 	}
+					 }
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100))
+			}
+
+			for (const mix of Object.keys(mixes)) {
+				let mixConfig = mixes[mix]
+					for (const layout of ['mono', 'stereo']) {
+					let numberOfMixes = this.config[layout + mix[0].toUpperCase() + mix.slice(1)] || 0
+					let offset = layout === 'stereo' ? mixConfig.stereoOffset : 0
+
+					for (let sendChannel = 1; sendChannel <= numberOfMixes; sendChannel++) {
+						this.midiSocket.send(Buffer.from([...sysExHeader, mixConfig.n, 5, 0x0b, 0x17, offset + sendChannel - 1, 0xF7]))
+					}
+				}
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ const { InstanceBase, Regex, runEntrypoint, TCPHelper } = require('@companion-mo
 const actions = require('./actions')
 const upgradeScripts = require('./upgrade')
 
+const sysExHeader = [0xF0, 0, 0, 0x1a, 0x50, 0x10, 1, 0];
+
+
 /**
  * @extends InstanceBase
  * @since 2.0.0
@@ -66,7 +69,7 @@ class ModuleInstance extends InstanceBase {
 		let chOfs = 0
 		let strip = parseInt(opt.strip)
 		let cmd = { port: this.config.midiPort, buffers: [] }
-
+    this.log("info", "action: " + actionId)
 		switch (
 			actionId // Note that only available actions for the type (TCP or MIDI) will be processed
 		) {
@@ -198,22 +201,22 @@ class ModuleInstance extends InstanceBase {
 			case 'send_mix':
 			case 'send_fx':
 			case 'send_ufx':
+				// TODO: probably for iLive this needs another command? 
+
 				// SysEx messages for send levels
 				let inputCh = parseInt(opt.inputChannel)
 				let sendCh = parseInt(opt.send)
 				let sendLevel = parseInt(opt.level)
-				let sendType = 0x01 // Default for aux sends
+				let sendType = 0x02 // Default for aux sends
 				
-				if (actionId.includes('fx') && !actionId.includes('ufx')) {
-					sendType = 0x02 // FX sends
-				} else if (actionId.includes('matrix')) {
+				if (actionId.includes('matrix')) {
 					sendType = 0x03 // Matrix sends
-				} else if (actionId.includes('ufx')) {
-					sendType = 0x04 // UFX sends
+				} else if (actionId.includes('fx')) {
+					sendType = 0x04 // FX and UFX sends
 				}
 				
 				cmd.buffers = [
-					Buffer.from([0xf0, 0, 0, 0x1a, 0x50, 0x10, 0x01, 0, 0, sendType, inputCh, sendCh, sendLevel, 0xf7]),
+					Buffer.from([...sysExHeader, 0, 0x0D, inputCh, sendType, sendCh, sendLevel, 0xf7]),
 				]
 				break
 

--- a/index.js
+++ b/index.js
@@ -405,7 +405,8 @@ class ModuleInstance extends InstanceBase {
 	 * @access public
 	 * @since 1.2.0
 	 */
-	async init() {
+	async init(config) {
+		this.config = config;
 		// Initialize with current config or empty object if not set yet
 		await this.configUpdated(this.config || {})
 	}

--- a/index.js
+++ b/index.js
@@ -8,6 +8,17 @@
 const { InstanceBase, Regex, runEntrypoint, TCPHelper } = require('@companion-module/base')
 const actions = require('./actions')
 const upgradeScripts = require('./upgrade')
+const MidiParser = require('./midi')
+const { FadingWorker } = require('./fades')
+
+const sysExHeader = [0xF0, 0, 0, 0x1a, 0x50, 0x10, 1, 0];
+
+let mixes = {
+	group: {n: 1, stereoOffset: 0x40},
+	aux: {n: 2, stereoOffset: 0x40},
+	fx: {n: 4, stereoOffset: 0x10},
+	matrix: {n: 3, stereoOffset: 0x40}
+}
 
 /**
  * @extends InstanceBase
@@ -27,6 +38,8 @@ class ModuleInstance extends InstanceBase {
 		Object.assign(this, {
 			...actions,
 		})
+
+		this.fadingWorker = new FadingWorker(this)
 	}
 
 	/**
@@ -50,6 +63,110 @@ class ModuleInstance extends InstanceBase {
 		}
 
 		return routingCmds
+	}
+
+
+	sendActionWithFade(actionId, opt) {
+		let path;
+		let inputCh = parseInt(opt.strip)
+		switch(actionId) {
+			case 'fader_input':
+			case 'fader_mix':
+				path = `0/${inputCh}/faderLevel`
+				break
+
+			case 'fader_mono_group':
+			case 'fader_stereo_group':
+				path = `1/${inputCh}/faderLevel`
+				break
+
+			case 'fader_mono_aux':
+			case 'fader_stereo_aux':
+				path = `2/${inputCh}/faderLevel`
+				break
+
+			case 'fader_mono_matrix':
+			case 'fader_stereo_matrix':
+				path = `3/${inputCh}/faderLevel`
+				break
+
+			case 'fader_DCA':
+			case 'fader_mono_fx_send':
+			case 'fader_stereo_fx_send':
+			case 'fader_fx_return':
+			case 'fader_ufx_send':
+			case 'fader_ufx_return':
+				let n = this.config.model == 'dLive' ? 4 : 0
+				path = `${n}/${inputCh}/faderLevel`
+				break
+			case 'send_aux_mono':
+			case 'send_aux_stereo':
+			case 'send_fx_mono':
+			case 'send_fx_stereo':
+			case 'send_matrix_mono':
+			case 'send_matrix_stereo':
+			case 'send_mix':
+			case 'send_fx':
+			case 'send_ufx':
+				inputCh = parseInt(opt.inputChannel)
+				let sendCh = parseInt(opt.send)
+				
+				let sendN = 0x02 // Default for aux sends
+				
+				if (actionId.includes('matrix')) {
+					sendN = 0x03 // Matrix sends
+				} else if (actionId.includes('fx')) {
+					sendN = 0x04 // FX and UFX sends
+				}
+				path = `0/${inputCh}/sendLevels/${sendN}/${sendCh}`
+				break;
+		}
+		let target = parseInt(opt.level)
+
+		let current = this.state.get(path) || 0
+		this.state.set(path, target)
+		this.fadingWorker.run(
+				path,
+				current,
+				target,
+				parseInt(opt.fadeDuration),
+				opt.fadeAlgorithm,
+				opt.fadeType,
+				true,
+		)
+	}
+
+	sendValueByPath(path, value) {
+		const parts = path.split("/")
+		const [n, channel, type] = parts
+		let cmd = { port: this.config.midiPort, buffers: [] }
+		switch (type) {
+			case "sendLevels":
+				const sendN = parts[3]
+				const sendChannel = parts[4]
+				cmd.buffers.push(Buffer.from([...sysExHeader, parseInt(n), 0x0D, parseInt(channel), sendN, sendChannel, value, 0xf7]))
+				break;
+			case "faderLevel":
+				cmd.buffers.push(
+					Buffer.from([0xb0 + parseInt(n), 0x63, parseInt(channel), 0x62, 0x17, 0x06, value])
+				)
+				break;
+			
+		}
+
+		for (let i = 0; i < cmd.buffers.length; i++) {
+			if (cmd.port === this.config.midiPort && this.midiSocket !== undefined) {
+				this.log('debug', `sending ${type} ${cmd.buffers[i].toString('hex')} via MIDI @${this.config.host}:${this.config.midiPort}`)
+				this.midiSocket.send(cmd.buffers[i]).catch((e) => {
+					this.log('error', `MIDI send error: ${e.message}`)
+				})
+			} else if (this.tcpSocket !== undefined) {
+				this.log('debug', `sending ${cmd.buffers[i].toString('hex')} via TCP @${this.config.host}:${this.config.tcpPort}`)
+				this.tcpSocket.send(cmd.buffers[i]).catch((e) => {
+					this.log('error', `TCP send error: ${e.message}`)
+				})
+			}
+		}
 	}
 
 	/**
@@ -372,10 +489,82 @@ class ModuleInstance extends InstanceBase {
 				type: 'number',
 				id: 'midiChannel',
 				label: 'MIDI Channel for dLive System (N)',
-				width: 6,
+				width: 12,
 				default: 0,
 				min: 0,
 				max: 15,
+			},
+			{
+				type: 'number',
+				id: 'monoGroup',
+				label: 'Number of Mono Groups',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoGroup',
+				label: 'Number of Stereo Groups',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'monoFx',
+				label: 'Number of Mono FX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoFx',
+				label: 'Number of Stereo FX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'monoAux',
+				label: 'Number of Mono AUX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoAux',
+				label: 'Number of Stereo AUX',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'monoMatrix',
+				label: 'Number of Mono Matrices',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
+			},
+			{
+				type: 'number',
+				id: 'stereoMatrix',
+				label: 'Number of Stereo Matrices',
+				width: 6,
+				default: 0,
+				min: 0,
+				max: 64,
 			},
 		]
 	}
@@ -410,6 +599,45 @@ class ModuleInstance extends InstanceBase {
 		await this.configUpdated(this.config || {})
 	}
 
+	parseMidiMessage(message) {
+		if (message.type === 0xF0) {
+			let command = message.raw[9];
+			let n = message.raw[8];
+			let channel = message.raw[10];
+			
+			// Send levels
+			if (command === 0x0D) {
+				let sendN = message.raw[11];
+				let sendChannel = message.raw[12];
+				let level = message.raw[13];
+
+				this.log("debug", `Received send level ${n} ${channel} ${sendN} ${sendChannel} ${level}`)
+				this.state.set(`${n}/${channel}/sendLevels/${sendN}/${sendChannel}`, level)
+			}
+		} else if (message.type === 0xB0) {
+			// NPRN message: typically three messages in a row to change a channel parameter
+			// 1. Select the channel
+			// 2. Select the paramter
+			// 3. Set the parameter value
+			// 
+			if (message.controller === 0x63) {
+				this.currentMidiChannel = {
+					n: message.channel,
+					channel: message.value
+				}
+			} else if (message.controller === 0x62) {
+				this.currentMidiParameter = message.value
+			} else if (message.controller === 0x06) {
+				if (this.currentMidiChannel && this.currentMidiParameter) {
+					if (this.currentMidiParameter === 0x17) {
+						this.log("debug", `Received fader level ${this.currentMidiChannel.n}/${this.currentMidiChannel.channel}/faderLevel`)
+						this.state.set(`${this.currentMidiChannel.n}/${this.currentMidiChannel.channel}/faderLevel`, message.value)
+					}
+				}
+			}
+		}
+	}
+
 	/**
 	 * INTERNAL: use setup data to initalize the tcp socket object.
 	 *
@@ -417,6 +645,7 @@ class ModuleInstance extends InstanceBase {
 	 * @since 2.0.0
 	 */
 	init_tcp() {
+		this.state = new Map();
 		if (this.tcpSocket !== undefined) {
 			this.tcpSocket.destroy()
 			delete this.tcpSocket
@@ -440,6 +669,14 @@ class ModuleInstance extends InstanceBase {
 
 			this.midiSocket.on('connect', () => {
 				this.log('debug', `MIDI Connected to ${this.config.host}`)
+				this.requestMidiValues()
+			})
+			this.midiParser = new MidiParser();
+			this.midiSocket.on('data', (e) => {
+				this.midiParser.processData(e)
+			})
+			this.midiParser.addListener("message", (message) => {
+				this.parseMidiMessage(message)
 			})
 
 			if (this.config.model == 'dLive') {
@@ -456,6 +693,39 @@ class ModuleInstance extends InstanceBase {
 				this.tcpSocket.on('connect', () => {
 					this.log('debug', `TCP Connected to ${this.config.host}`)
 				})
+			}
+		}
+	}
+
+	async requestMidiValues() {
+		if (this.config.model === "dLive") {
+			// Request fader and send level of all input channels
+			for (let i = 0; i < 128; i++) {
+				this.midiSocket.send(Buffer.from([...sysExHeader, 0, 5, 0x0b, 0x17, i, 0xF7]))
+				for (const mix of Object.keys(mixes)) {
+					let mixConfig = mixes[mix]
+					 for (const layout of ['mono', 'stereo']) {
+					 	let numberOfMixes = this.config[layout + mix[0].toUpperCase() + mix.slice(1)] || 0
+					 	let offset = layout === 'stereo' ? mixConfig.stereoOffset : 0
+
+					 	for (let sendChannel = 1; sendChannel <= numberOfMixes; sendChannel++) {
+					 		this.midiSocket.send(Buffer.from([...sysExHeader, 0, 5, 0x0F, 0x0D, i, mixConfig.n, offset + sendChannel - 1, 0xF7]))
+					 	}
+					 }
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100))
+			}
+
+			for (const mix of Object.keys(mixes)) {
+				let mixConfig = mixes[mix]
+					for (const layout of ['mono', 'stereo']) {
+					let numberOfMixes = this.config[layout + mix[0].toUpperCase() + mix.slice(1)] || 0
+					let offset = layout === 'stereo' ? mixConfig.stereoOffset : 0
+
+					for (let sendChannel = 1; sendChannel <= numberOfMixes; sendChannel++) {
+						this.midiSocket.send(Buffer.from([...sysExHeader, mixConfig.n, 5, 0x0b, 0x17, offset + sendChannel - 1, 0xF7]))
+					}
+				}
 			}
 		}
 	}

--- a/midi.js
+++ b/midi.js
@@ -1,0 +1,192 @@
+const { EventEmitter } = require('events')
+
+class MidiParser extends EventEmitter {
+    constructor() {
+        super()
+        this.buffer = Buffer.alloc(0)
+        this.lastStatusByte = null
+        this.sysexBuffer = null
+    }
+
+    /**
+     * Process incoming data from socket
+     * @param {Buffer} data - Raw data buffer from socket
+     */
+    processData(data) {
+        this.buffer = Buffer.concat([this.buffer, data])
+        this.parseMessages()
+    }
+
+    /**
+     * Parse MIDI messages from buffer
+     */
+    parseMessages() {
+        while (this.buffer.length > 0) {
+            let statusByte = this.buffer[0]
+            
+            // Handle SysEx messages
+            if (statusByte === 0xf0) {
+                this.parseSysEx()
+                continue
+            }
+            
+            // End of SysEx (shouldn't happen outside of SysEx parsing)
+            if (statusByte === 0xf7) {
+                this.buffer = this.buffer.slice(1)
+                continue
+            }
+            
+            let dataStartIndex = 1
+            
+            // Check if this is a data byte (running status)
+            if ((statusByte & 0x80) === 0) {
+                if (this.lastStatusByte === null) {
+                    // No running status available, skip this byte
+                    this.buffer = this.buffer.slice(1)
+                    continue
+                }
+                // Use running status
+                statusByte = this.lastStatusByte
+                dataStartIndex = 0
+            } else {
+                // Store new status byte for running status (not for system messages)
+                if ((statusByte & 0xf0) !== 0xf0) {
+                    this.lastStatusByte = statusByte
+                }
+            }
+
+            const messageType = statusByte & 0xf0
+            const channel = statusByte & 0x0f
+
+            let messageLength = this.getMessageLength(messageType)
+            
+            if (messageLength === 0) {
+                this.buffer = this.buffer.slice(1)
+                continue
+            }
+
+            // Adjust length for running status (no status byte in buffer)
+            const requiredBytes = dataStartIndex === 0 ? messageLength - 1 : messageLength
+            
+            if (this.buffer.length < requiredBytes) {
+                break // Wait for more data
+            }
+
+            // Reconstruct message with status byte
+            let message
+            if (dataStartIndex === 0) {
+                // Running status: prepend status byte
+                message = Buffer.concat([
+                    Buffer.from([statusByte]),
+                    this.buffer.slice(0, messageLength - 1)
+                ])
+                this.buffer = this.buffer.slice(messageLength - 1)
+            } else {
+                message = this.buffer.slice(0, messageLength)
+                this.buffer = this.buffer.slice(messageLength)
+            }
+
+            this.emitMessage(messageType, channel, message)
+        }
+    }
+
+    /**
+     * Parse System Exclusive message
+     */
+    parseSysEx() {
+        // Find end of SysEx (0xF7)
+        const endIndex = this.buffer.indexOf(0xf7)
+        
+        if (endIndex === -1) {
+            // SysEx not complete yet, wait for more data
+            return
+        }
+        
+        // Extract complete SysEx message including 0xF0 and 0xF7
+        const sysexMessage = this.buffer.slice(0, endIndex + 1)
+        this.buffer = this.buffer.slice(endIndex + 1)
+        
+        // Emit SysEx message
+        this.emit('sysex', {
+            type: 0xf0,
+            raw: sysexMessage,
+            data: sysexMessage.slice(1, -1) // Data without 0xF0 and 0xF7
+        })
+        
+        this.emit('message', {
+            type: 0xf0,
+            raw: sysexMessage,
+            data: sysexMessage.slice(1, -1)
+        })
+    }
+
+    /**
+     * Get expected message length based on status byte
+     * @param {number} messageType - MIDI message type
+     * @returns {number} Expected message length in bytes
+     */
+    getMessageLength(messageType) {
+        switch (messageType) {
+            case 0x80: // Note Off
+            case 0x90: // Note On
+            case 0xa0: // Polyphonic Aftertouch
+            case 0xb0: // Control Change
+            case 0xe0: // Pitch Bend
+                return 3
+            case 0xc0: // Program Change
+            case 0xd0: // Channel Aftertouch
+                return 2
+            default:
+                return 0
+        }
+    }
+
+    /**
+     * Emit parsed MIDI message
+     * @param {number} messageType - MIDI message type
+     * @param {number} channel - MIDI channel (0-15)
+     * @param {Buffer} message - Complete MIDI message
+     */
+    emitMessage(messageType, channel, message) {
+        const data = {
+            type: messageType,
+            channel: channel,
+            raw: message
+        }
+
+        switch (messageType) {
+            case 0x90: // Note On
+            case 0x80: // Note Off
+                data.note = message[1]
+                data.velocity = message[2]
+                this.emit(messageType === 0x90 ? 'noteOn' : 'noteOff', data)
+                break
+            case 0xb0: // Control Change
+                data.controller = message[1]
+                data.value = message[2]
+                this.emit('controlChange', data)
+                break
+            case 0xe0: // Pitch Bend
+                data.value = (message[2] << 7) | message[1]
+                this.emit('pitchBend', data)
+                break
+            case 0xc0: // Program Change
+                data.program = message[1]
+                this.emit('programChange', data)
+                break
+        }
+
+        this.emit('message', data)
+    }
+
+    /**
+     * Clear internal buffer
+     */
+    clear() {
+        this.buffer = Buffer.alloc(0)
+        this.lastStatusByte = null
+        this.sysexBuffer = null
+    }
+}
+
+module.exports = MidiParser


### PR DESCRIPTION
Adds support for transitions on set fader level and set send level actions.
The main use case for that is to enable cross-fades between different channels.

The implementation is heavily inspired and copied from the [Behringer WING module](https://github.com/bitfocus/companion-module-behringer-wing)